### PR TITLE
Updates to scenes functionalilty for bridge API v1.11

### DIFF
--- a/bin/lights
+++ b/bin/lights
@@ -73,7 +73,7 @@ class LightsCli
       OptionParser.new do |opts|
         opts.on("-l", "--lights 1,2,...N", Array, "Which lights are in the scene"){|l| options[:lights]=l}
         opts.on("-n", "--name <name>", String, "Set scene name"){|n| options[:name]=n}
-        opts.on("-i", "--id <id>", String, "Set scene ID"){|i| options[:id]=i}
+        opts.on("-r", "--recycle", "Can bridge recycle scene"){|r| options[:recycle]=r}
       end.parse!
 
       if !options[:lights]
@@ -84,14 +84,15 @@ class LightsCli
         puts "Must specify scene name."
         exit 1
       end
-      if !options[:id]
-        puts "Must specify scene id."
-        exit 1
+      if !options[:recycle]
+        puts "Must specify if scene can be recycled by bridge. --recycle [true|false]"
+        exit
       end
 
-      s = Scene.new options[:id]
+      s = Scene.new
       s.name = options[:name]
       s.lights = options[:lights]
+      s.recycle = options[:recycle]
       hue.create_scene s
     when "group"
       OptionParser.new do |opts|
@@ -192,7 +193,14 @@ class LightsCli
 
       hue.delete_user id
     when "scene"
-      STDERR.puts "Cannot delete scenes."
+      id = ARGV.shift
+
+      if !id
+        puts "Must specify scene id."
+        exit 1
+      end
+
+      hue.delete_scene id
     when nil
       STDERR.puts "Must specify a type to delete."
     else
@@ -231,8 +239,8 @@ class LightsCli
     when "scenes"
       response = hue.request_scene_list
       objects = SceneList.new(response)
-      titles = ["ID","NAME","LIGHTS"]
-      methods = [:id,:name,:lights]
+      titles = ["ID","NAME","LIGHTS","RECYCLE"]
+      methods = [:id,:name,:lights,:recycle]
     when "users"
       response = hue.request_config
       objects = UserList.new(response["whitelist"])

--- a/bin/lights
+++ b/bin/lights
@@ -74,6 +74,7 @@ class LightsCli
         opts.on("-l", "--lights 1,2,...N", Array, "Which lights are in the scene"){|l| options[:lights]=l}
         opts.on("-n", "--name <name>", String, "Set scene name"){|n| options[:name]=n}
         opts.on("-r", "--recycle", "Can bridge recycle scene"){|r| options[:recycle]=r}
+        opts.on("-d", "--duration seconds", OptionParser::DecimalInteger, "Transition duration in seconds"){|d| options[:duration]=d}
       end.parse!
 
       if !options[:lights]
@@ -93,6 +94,7 @@ class LightsCli
       s.name = options[:name]
       s.lights = options[:lights]
       s.recycle = options[:recycle]
+      s.transition_time = options[:duration]
       hue.create_scene s
     when "group"
       OptionParser.new do |opts|

--- a/bin/lights
+++ b/bin/lights
@@ -85,15 +85,11 @@ class LightsCli
         puts "Must specify scene name."
         exit 1
       end
-      if !options[:recycle]
-        puts "Must specify if scene can be recycled by bridge. --recycle [true|false]"
-        exit
-      end
 
       s = Scene.new
       s.name = options[:name]
       s.lights = options[:lights]
-      s.recycle = options[:recycle]
+      s.recycle = options[:recycle] || false
       s.transition_time = options[:duration]
       hue.create_scene s
     when "group"

--- a/lib/lights.rb
+++ b/lib/lights.rb
@@ -139,7 +139,11 @@ class Lights
   end
 
   def create_scene( scene )
-    put "scenes/#{scene.id}", scene
+    post "scenes/#{scene.id}", scene
+  end
+
+  def delete_scene( id )
+    delete "scenes/#{id}"
   end
 
   def delete_group( id )

--- a/lib/lights.rb
+++ b/lib/lights.rb
@@ -174,6 +174,8 @@ private
       raise ParameterUnavailableException, result["error"]["description"]
     when 101
       raise BridgeConnectException
+    when 403
+      raise SceneLockedException, result["error"]["description"]
     else
       raise "Unknown Error: #{result["error"]["description"]}"
     end

--- a/lib/lights/exception.rb
+++ b/lib/lights/exception.rb
@@ -33,3 +33,9 @@ class ParameterUnavailableException < Exception
     super
   end
 end
+
+class SceneLockedException < Exception
+  def initialize(msg = "Scene could not be removed, because it's locked.")
+    super
+  end
+end

--- a/lib/lights/scene.rb
+++ b/lib/lights/scene.rb
@@ -1,13 +1,14 @@
 require 'lights/hobject'
 
 class Scene < HObject
-  attr_accessor :id, :name, :active, :lights, :recycle
+  attr_accessor :id, :name, :active, :lights, :recycle, :transition_time
   def initialize(id = nil,data = {})
     @id = id
     @name = data["name"]
     @active = data["active"]
     @lights = data["lights"]
     @recycle = data["recycle"]
+    @transition_time = data["transitiontime"]
   end
 
   def data
@@ -16,6 +17,7 @@ class Scene < HObject
     data["active"] = @active unless @active.nil?
     data["lights"] = @lights if @lights
     data["recycle"] = @recycle if @recycle
+    data["transitiontime"] = @transition_time if @transition_time
     data
   end
 end

--- a/lib/lights/scene.rb
+++ b/lib/lights/scene.rb
@@ -16,7 +16,7 @@ class Scene < HObject
     data["name"] = @name if @name
     data["active"] = @active unless @active.nil?
     data["lights"] = @lights if @lights
-    data["recycle"] = @recycle if @recycle
+    data["recycle"] = @recycle unless @recycle.nil?
     data["transitiontime"] = @transition_time if @transition_time
     data
   end

--- a/lib/lights/scene.rb
+++ b/lib/lights/scene.rb
@@ -1,12 +1,13 @@
 require 'lights/hobject'
 
 class Scene < HObject
-  attr_accessor :id, :name, :active, :lights
-  def initialize(id,data = {})
+  attr_accessor :id, :name, :active, :lights, :recycle
+  def initialize(id = nil,data = {})
     @id = id
     @name = data["name"]
     @active = data["active"]
     @lights = data["lights"]
+    @recycle = data["recycle"]
   end
 
   def data
@@ -14,6 +15,7 @@ class Scene < HObject
     data["name"] = @name if @name
     data["active"] = @active unless @active.nil?
     data["lights"] = @lights if @lights
+    data["recycle"] = @recycle if @recycle
     data
   end
 end


### PR DESCRIPTION
* Breaks compatibility with versions <1.11 for scene creation.
* Specify 'recycle' attribute when creating scenes.
* Add 'recycle' to the list scenes table.
* Add ability to delete scenes.
* Added handling for error code 403: scene is locked


Changes to Scenes API in v1.11:
4.1.1 Modified description.
4.1.2 Added descriptions for new fields: owner, locked, picture and version.
4.1.3 Added JSON Example for a scene created with 1.11.
4.1.4 Added note saying active flag is no longer returned from the bridge. Deprecated
4.2 Added description on new way of creating scenes
4.3 Added description on new way of modifying scenes
4.3.2 Added description for new storelightstate field
4.3.3 and 4.3.4 Added JSON examples for modifying scene names/lights and storing the current values.
4.5 Delete scenes description added
4.6 Get scene description added
Changes to the Error messages.
Added 306, 403, 706, 801, 802 and 803 error codes
https://www.developers.meethue.com/documentation/changelog